### PR TITLE
Add Windows build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.test
 icmptun_server
 icmptun_client
+output/

--- a/build_windows.sh
+++ b/build_windows.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Build Windows executables for icmptun client and server.
+# The binaries are placed in the output directory.
+set -e
+
+OUT_DIR="output"
+mkdir -p "$OUT_DIR"
+
+echo "Building Windows client..."
+GOOS=windows GOARCH=amd64 go build -o "$OUT_DIR/icmptun_client.exe" ./client
+
+echo "Building Windows server..."
+GOOS=windows GOARCH=amd64 go build -o "$OUT_DIR/icmptun_server.exe" ./server
+
+echo "Binaries built in $OUT_DIR"


### PR DESCRIPTION
## Summary
- update `.gitignore` to ignore `output/`
- add `build_windows.sh` to build Windows executables for client and server

## Testing
- `./build_windows.sh`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68652eb9c7708327aeff027f48c3b9cf