### PR TITLE
Implement ICMP checksum with tests

### DIFF
--- a/xnet/icmp/icmp.go
+++ b/xnet/icmp/icmp.go
@@ -43,7 +43,24 @@ func ListenPacket(network, address string) (net.PacketConn, error) {
 	return net.ListenPacket(network, address)
 }
 
-// Marshal 编码 ICMP 消息，简化处理未计算校验和
+// checksum calculates the ICMP checksum for the given data using the standard
+// one's complement sum.
+func checksum(b []byte) uint16 {
+	var sum uint32
+	for len(b) > 1 {
+		sum += uint32(binary.BigEndian.Uint16(b))
+		b = b[2:]
+	}
+	if len(b) > 0 {
+		sum += uint32(b[0]) << 8
+	}
+	for (sum >> 16) > 0 {
+		sum = (sum >> 16) + (sum & 0xffff)
+	}
+	return ^uint16(sum)
+}
+
+// Marshal 编码 ICMP 消息并计算校验和
 func (m *Message) Marshal(_ []byte) ([]byte, error) {
 	if m.Body == nil {
 		return nil, errors.New("nil body")
@@ -56,7 +73,9 @@ func (m *Message) Marshal(_ []byte) ([]byte, error) {
 	b[0] = byte(m.Type)
 	b[1] = byte(m.Code)
 	copy(b[4:], body)
-	// 校验和置零
+	binary.BigEndian.PutUint16(b[2:4], 0)
+	csum := checksum(b)
+	binary.BigEndian.PutUint16(b[2:4], csum)
 	return b, nil
 }
 

--- a/xnet/icmp/icmp_test.go
+++ b/xnet/icmp/icmp_test.go
@@ -1,0 +1,43 @@
+package icmp
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"golang.org/x/net/ipv4"
+)
+
+// manualChecksum independently calculates the ICMP checksum.
+func manualChecksum(b []byte) uint16 {
+	var sum uint32
+	for len(b) > 1 {
+		sum += uint32(binary.BigEndian.Uint16(b))
+		b = b[2:]
+	}
+	if len(b) > 0 {
+		sum += uint32(b[0]) << 8
+	}
+	for (sum >> 16) > 0 {
+		sum = (sum >> 16) + (sum & 0xffff)
+	}
+	return ^uint16(sum)
+}
+
+func TestMessageMarshalChecksum(t *testing.T) {
+	msg := &Message{
+		Type: ipv4.ICMPTypeEcho,
+		Code: 0,
+		Body: &Echo{ID: 0x1234, Seq: 1, Data: []byte("Hello")},
+	}
+	b, err := msg.Marshal(nil)
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+	bZero := append([]byte(nil), b...)
+	binary.BigEndian.PutUint16(bZero[2:4], 0)
+	want := manualChecksum(bZero)
+	got := binary.BigEndian.Uint16(b[2:4])
+	if got != want {
+		t.Errorf("checksum mismatch: got 0x%x, want 0x%x", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- implement checksum helper for ICMP messages
- compute checksum in `Message.Marshal`
- add unit test verifying checksum calculation

## Testing
- `go test ./...`
- `cd xnet && go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686534c440ac8327b29e4fe116d4d267